### PR TITLE
feat(daemon): keep tasks pending until an agent is available

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -74,6 +74,9 @@ func NewServer(cfg *Config) (*Server, error) {
 	tasks := NewTaskRouter(store, processes, eventCh)
 	names := NewNameGenerator()
 
+	// Wire up callback to process pending tasks when agents become available
+	processes.SetOnAgentAvailable(tasks.ProcessPendingTasks)
+
 	s := &Server{
 		store:      store,
 		tasks:      tasks,


### PR DESCRIPTION
## Summary
- Tasks now remain in PENDING state until an available agent can handle them
- Added `ProcessPendingTasks()` method to TaskRouter that assigns pending tasks to available agents
- Added callback mechanism in ProcessManager to trigger task processing when agents become available (spawned or finish a task)

Closes #10

## Test plan
- [ ] Submit tasks when no agents exist - verify they stay pending
- [ ] Spawn an agent - verify pending tasks get assigned automatically
- [ ] Submit multiple tasks with one agent - verify they're processed one at a time
- [ ] Verify `make test` passes
- [ ] Verify `golangci-lint run` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)