### PR TITLE
fix(cli): use project node ID for GitHub status updates

### DIFF
--- a/internal/cli/task_sync.go
+++ b/internal/cli/task_sync.go
@@ -14,6 +14,7 @@ import (
 
 // GitHub Project data structures for JSON parsing
 type ghProject struct {
+	ID     string `json:"id"`
 	Number int    `json:"number"`
 	Title  string `json:"title"`
 }
@@ -200,7 +201,7 @@ func runTaskSyncGHProject(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  Created task: %s\n", task.TaskId)
 
 		// Update item status on GitHub
-		if err := updateItemStatus(project.Number, item.ID, statusField.ID, targetOptionID); err != nil {
+		if err := updateItemStatus(project.ID, item.ID, statusField.ID, targetOptionID); err != nil {
 			fmt.Printf("  Warning: failed to update GitHub status: %v\n", err)
 		} else {
 			fmt.Printf("  Moved to %q on GitHub\n", syncTargetColumn)
@@ -307,10 +308,10 @@ func buildTaskDescription(item ghItem) string {
 	return sb.String()
 }
 
-func updateItemStatus(projectNumber int, itemID, fieldID, optionID string) error {
+func updateItemStatus(projectID, itemID, fieldID, optionID string) error {
 	args := []string{
 		"project", "item-edit",
-		"--project-id", fmt.Sprintf("%d", projectNumber),
+		"--project-id", projectID,
 		"--id", itemID,
 		"--field-id", fieldID,
 		"--single-select-option-id", optionID,


### PR DESCRIPTION
## Summary

- Fixed `map task sync gh-project` failing to update item status on GitHub after task creation
- The `gh project item-edit` command requires the GraphQL node ID (e.g., `PVT_kwHOAA2t284BNI4p`), not the project number
- Added `ID` field to `ghProject` struct and updated `updateItemStatus` to use it

## Test plan

- [x] All existing tests pass
- [x] Linter passes
- [ ] Run `map task sync gh-project "<project-name>"` and verify items move to "In Progress" without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)