### PR TITLE
feat: add Zellij as alternative terminal multiplexer

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -67,6 +67,7 @@ func initConfig() error {
 	// Set defaults
 	viper.SetDefault("socket", "/tmp/mapd.sock")
 	viper.SetDefault("data-dir", filepath.Join(os.Getenv("HOME"), ".mapd"))
+	viper.SetDefault("multiplexer", "tmux") // terminal multiplexer: "tmux" or "zellij"
 	viper.SetDefault("agent.default-type", "claude")
 	viper.SetDefault("agent.default-count", 1)
 	viper.SetDefault("agent.default-branch", "")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -32,6 +32,12 @@ func getSocketPath() string {
 	return viper.GetString("socket")
 }
 
+// getMultiplexer returns the multiplexer type from Viper (env > config > default)
+// Returns "tmux" or "zellij"
+func getMultiplexer() string {
+	return viper.GetString("multiplexer")
+}
+
 func init() {
 	rootCmd.PersistentFlags().StringP("socket", "s", "/tmp/mapd.sock", "daemon socket path")
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: ~/.mapd/config.yaml)")

--- a/internal/cli/up.go
+++ b/internal/cli/up.go
@@ -20,8 +20,15 @@ var (
 var upCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Start the mapd daemon",
-	Long:  `Start the mapd daemon process. By default runs in the background.`,
-	RunE:  runUp,
+	Long: `Start the mapd daemon process. By default runs in the background.
+
+The terminal multiplexer can be configured via:
+  - 'multiplexer' in ~/.mapd/config.yaml
+  - MAP_MULTIPLEXER environment variable
+  - defaults to 'tmux' if not specified
+
+Supported multiplexers: tmux, zellij`,
+	RunE: runUp,
 }
 
 func init() {
@@ -46,8 +53,9 @@ func runUp(cmd *cobra.Command, args []string) error {
 
 func runForeground() error {
 	cfg := &daemon.Config{
-		SocketPath: getSocketPath(),
-		DataDir:    dataDir,
+		SocketPath:  getSocketPath(),
+		DataDir:     dataDir,
+		Multiplexer: getMultiplexer(),
 	}
 
 	srv, err := daemon.NewServer(cfg)

--- a/internal/daemon/multiplexer.go
+++ b/internal/daemon/multiplexer.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"os"
+	"os/exec"
+)
+
+// Multiplexer interface abstracts terminal multiplexer operations (tmux, zellij)
+type Multiplexer interface {
+	// Session lifecycle
+	CreateSession(name, workdir, command string) error
+	KillSession(name string) error
+	HasSession(name string) bool
+	ListSessions(prefix string) ([]string, error)
+
+	// Session interaction
+	SendText(sessionName, text string) error
+	SendEnter(sessionName string) error
+	RespawnPane(sessionName, command string) error
+
+	// Session info
+	GetPaneWorkdir(sessionName string) string
+	GetPaneTitle(sessionName string) string
+	IsPaneDead(sessionName string) bool
+
+	// Attachment (returns command to exec)
+	AttachCommand(sessionName string) *exec.Cmd
+
+	// Configuration
+	ConfigureSession(sessionName string, opts SessionOptions) error
+
+	// Identification
+	Name() string // "tmux" or "zellij"
+}
+
+// SessionOptions contains configuration options for multiplexer sessions
+type SessionOptions struct {
+	AgentID        string
+	MouseEnabled   bool
+	StatusBarLabel string
+	CLICommand     string // The CLI command used to respawn (e.g., "claude --dangerously-skip-permissions")
+}
+
+// MultiplexerType represents supported multiplexer types
+type MultiplexerType string
+
+const (
+	MultiplexerTmux   MultiplexerType = "tmux"
+	MultiplexerZellij MultiplexerType = "zellij"
+)
+
+// NewMultiplexer creates a multiplexer instance based on the specified type
+func NewMultiplexer(muxType MultiplexerType) (Multiplexer, error) {
+	switch muxType {
+	case MultiplexerZellij:
+		return NewZellijMultiplexer()
+	default:
+		return NewTmuxMultiplexer()
+	}
+}
+
+// GetMultiplexerType determines multiplexer type from environment or returns default
+func GetMultiplexerType() MultiplexerType {
+	if mux := os.Getenv("MAP_MULTIPLEXER"); mux != "" {
+		switch mux {
+		case "zellij":
+			return MultiplexerZellij
+		case "tmux":
+			return MultiplexerTmux
+		}
+	}
+	return MultiplexerTmux // default
+}

--- a/internal/daemon/multiplexer_tmux.go
+++ b/internal/daemon/multiplexer_tmux.go
@@ -1,0 +1,159 @@
+package daemon
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// TmuxMultiplexer implements the Multiplexer interface using tmux
+type TmuxMultiplexer struct{}
+
+// NewTmuxMultiplexer creates a new tmux multiplexer
+func NewTmuxMultiplexer() (*TmuxMultiplexer, error) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		return nil, fmt.Errorf("tmux not found in PATH: %w", err)
+	}
+	return &TmuxMultiplexer{}, nil
+}
+
+// Name returns the multiplexer name
+func (t *TmuxMultiplexer) Name() string {
+	return "tmux"
+}
+
+// CreateSession creates a new tmux session
+func (t *TmuxMultiplexer) CreateSession(name, workdir, command string) error {
+	cmd := exec.Command("tmux", "new-session", "-d", "-s", name, "-c", workdir, command)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create tmux session: %w", err)
+	}
+	return nil
+}
+
+// KillSession terminates a tmux session
+func (t *TmuxMultiplexer) KillSession(name string) error {
+	cmd := exec.Command("tmux", "kill-session", "-t", name)
+	return cmd.Run()
+}
+
+// HasSession checks if a tmux session exists
+func (t *TmuxMultiplexer) HasSession(name string) bool {
+	cmd := exec.Command("tmux", "has-session", "-t", name)
+	return cmd.Run() == nil
+}
+
+// ListSessions returns all tmux sessions with the given prefix
+func (t *TmuxMultiplexer) ListSessions(prefix string) ([]string, error) {
+	cmd := exec.Command("tmux", "list-sessions", "-F", "#{session_name}")
+	output, err := cmd.Output()
+	if err != nil {
+		// No sessions is not an error
+		return nil, nil
+	}
+
+	var sessions []string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(output)), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			sessions = append(sessions, line)
+		}
+	}
+	return sessions, nil
+}
+
+// SendText sends text to a tmux session using literal mode
+func (t *TmuxMultiplexer) SendText(sessionName, text string) error {
+	cmd := exec.Command("tmux", "send-keys", "-t", sessionName, "-l", text)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to send text to tmux: %w", err)
+	}
+	return nil
+}
+
+// SendEnter sends an Enter keypress to a tmux session
+func (t *TmuxMultiplexer) SendEnter(sessionName string) error {
+	cmd := exec.Command("tmux", "send-keys", "-t", sessionName, "Enter")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to send Enter to tmux: %w", err)
+	}
+	return nil
+}
+
+// RespawnPane respawns the pane with a new command
+func (t *TmuxMultiplexer) RespawnPane(sessionName, command string) error {
+	cmd := exec.Command("tmux", "respawn-pane", "-t", sessionName, "-k", command)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to respawn pane: %w", err)
+	}
+	return nil
+}
+
+// GetPaneWorkdir returns the current working directory of a tmux pane
+func (t *TmuxMultiplexer) GetPaneWorkdir(sessionName string) string {
+	cmd := exec.Command("tmux", "display-message", "-t", sessionName, "-p", "#{pane_current_path}")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+// GetPaneTitle returns the pane title of a tmux session
+func (t *TmuxMultiplexer) GetPaneTitle(sessionName string) string {
+	cmd := exec.Command("tmux", "display-message", "-t", sessionName, "-p", "#{pane_title}")
+	output, err := cmd.Output()
+	if err != nil {
+		return "unknown"
+	}
+	title := strings.TrimSpace(string(output))
+	if title == "" {
+		return "idle"
+	}
+	return title
+}
+
+// IsPaneDead checks if the pane's process has exited
+func (t *TmuxMultiplexer) IsPaneDead(sessionName string) bool {
+	cmd := exec.Command("tmux", "display-message", "-t", sessionName, "-p", "#{pane_dead}")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) == "1"
+}
+
+// AttachCommand returns an exec.Cmd that attaches to the session
+func (t *TmuxMultiplexer) AttachCommand(sessionName string) *exec.Cmd {
+	return exec.Command("tmux", "attach", "-t", sessionName)
+}
+
+// ConfigureSession applies configuration options to a tmux session
+func (t *TmuxMultiplexer) ConfigureSession(sessionName string, opts SessionOptions) error {
+	// Enable mouse scrolling
+	if opts.MouseEnabled {
+		_ = exec.Command("tmux", "set-option", "-t", sessionName, "mouse", "on").Run()
+	}
+
+	// Enable remain-on-exit to keep pane open if agent exits
+	_ = exec.Command("tmux", "set-option", "-t", sessionName, "remain-on-exit", "on").Run()
+
+	// Store the CLI command for respawn keybinding
+	if opts.CLICommand != "" {
+		_ = exec.Command("tmux", "set-option", "-t", sessionName, "@map_cli_cmd", opts.CLICommand).Run()
+		_ = exec.Command("tmux", "bind-key", "-t", sessionName, "R", "respawn-pane", "-k", opts.CLICommand).Run()
+	}
+
+	// Add agent ID to the status-right for easy identification
+	if opts.AgentID != "" {
+		statusRight := fmt.Sprintf(" [%s] %%H %%H:%%M %%d-%%b-%%y", opts.AgentID)
+		_ = exec.Command("tmux", "set-option", "-t", sessionName, "status-right", statusRight).Run()
+	}
+
+	// Apply a subtle theme (neutral grays that work on both dark and light terminals)
+	_ = exec.Command("tmux", "set-option", "-t", sessionName, "status-style", "bg=colour240,fg=colour255").Run()
+	_ = exec.Command("tmux", "set-option", "-t", sessionName, "status-left-style", "bg=colour243,fg=colour255").Run()
+	_ = exec.Command("tmux", "set-option", "-t", sessionName, "status-right-style", "bg=colour243,fg=colour255").Run()
+	_ = exec.Command("tmux", "set-option", "-t", sessionName, "window-status-current-style", "bg=colour245,fg=colour232,bold").Run()
+
+	return nil
+}

--- a/internal/daemon/multiplexer_zellij.go
+++ b/internal/daemon/multiplexer_zellij.go
@@ -1,0 +1,143 @@
+package daemon
+
+import (
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+)
+
+// ZellijMultiplexer implements the Multiplexer interface using Zellij
+type ZellijMultiplexer struct{}
+
+// NewZellijMultiplexer creates a new Zellij multiplexer
+func NewZellijMultiplexer() (*ZellijMultiplexer, error) {
+	if _, err := exec.LookPath("zellij"); err != nil {
+		return nil, fmt.Errorf("zellij not found in PATH: %w", err)
+	}
+	return &ZellijMultiplexer{}, nil
+}
+
+// Name returns the multiplexer name
+func (z *ZellijMultiplexer) Name() string {
+	return "zellij"
+}
+
+// CreateSession creates a new Zellij session
+// Zellij doesn't have a direct equivalent to tmux's new-session with a command,
+// so we create a session and then run the command in it
+func (z *ZellijMultiplexer) CreateSession(name, workdir, command string) error {
+	// Create a detached Zellij session with the specified working directory
+	// Using: zellij -s NAME options --default-cwd DIR -- CMD
+	cmd := exec.Command("zellij", "-s", name, "options", "--default-cwd", workdir, "--", command)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to create zellij session: %w", err)
+	}
+	return nil
+}
+
+// KillSession terminates a Zellij session
+func (z *ZellijMultiplexer) KillSession(name string) error {
+	cmd := exec.Command("zellij", "kill-session", name)
+	return cmd.Run()
+}
+
+// HasSession checks if a Zellij session exists
+func (z *ZellijMultiplexer) HasSession(name string) bool {
+	sessions, err := z.ListSessions("")
+	if err != nil {
+		return false
+	}
+	return slices.Contains(sessions, name)
+}
+
+// ListSessions returns all Zellij sessions with the given prefix
+func (z *ZellijMultiplexer) ListSessions(prefix string) ([]string, error) {
+	cmd := exec.Command("zellij", "list-sessions", "--short")
+	output, err := cmd.Output()
+	if err != nil {
+		// No sessions is not an error
+		return nil, nil
+	}
+
+	var sessions []string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(output)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if prefix == "" || strings.HasPrefix(line, prefix) {
+			sessions = append(sessions, line)
+		}
+	}
+	return sessions, nil
+}
+
+// SendText sends text to a Zellij session
+func (z *ZellijMultiplexer) SendText(sessionName, text string) error {
+	// zellij -s NAME action write-chars TEXT
+	cmd := exec.Command("zellij", "-s", sessionName, "action", "write-chars", text)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to send text to zellij: %w", err)
+	}
+	return nil
+}
+
+// SendEnter sends an Enter keypress to a Zellij session
+func (z *ZellijMultiplexer) SendEnter(sessionName string) error {
+	// zellij -s NAME action write 10 (10 is the ASCII code for newline/Enter)
+	cmd := exec.Command("zellij", "-s", sessionName, "action", "write", "10")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to send Enter to zellij: %w", err)
+	}
+	return nil
+}
+
+// RespawnPane respawns the pane with a new command
+// Zellij doesn't have direct pane respawn like tmux, so we close and reopen
+func (z *ZellijMultiplexer) RespawnPane(sessionName, command string) error {
+	// Zellij doesn't have a direct equivalent to tmux's respawn-pane
+	// We can try to run a new command in the session
+	// Using: zellij -s NAME run -- CMD
+	cmd := exec.Command("zellij", "-s", sessionName, "run", "--", command)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to respawn pane in zellij: %w", err)
+	}
+	return nil
+}
+
+// GetPaneWorkdir returns the working directory
+// Zellij doesn't expose this directly, so we return empty string
+func (z *ZellijMultiplexer) GetPaneWorkdir(sessionName string) string {
+	// Zellij doesn't have a direct way to query pane working directory
+	return ""
+}
+
+// GetPaneTitle returns the pane title
+// Zellij handles this differently than tmux
+func (z *ZellijMultiplexer) GetPaneTitle(sessionName string) string {
+	// Zellij doesn't have a direct equivalent to query pane title
+	return "zellij"
+}
+
+// IsPaneDead checks if the pane's process has exited
+// Zellij doesn't have a direct equivalent to tmux's pane_dead
+func (z *ZellijMultiplexer) IsPaneDead(sessionName string) bool {
+	// Zellij doesn't expose pane dead status directly
+	// We can check if the session still exists
+	return !z.HasSession(sessionName)
+}
+
+// AttachCommand returns an exec.Cmd that attaches to the session
+func (z *ZellijMultiplexer) AttachCommand(sessionName string) *exec.Cmd {
+	return exec.Command("zellij", "attach", sessionName)
+}
+
+// ConfigureSession applies configuration options to a Zellij session
+// Zellij uses config files rather than runtime options, so this is limited
+func (z *ZellijMultiplexer) ConfigureSession(sessionName string, opts SessionOptions) error {
+	// Zellij configuration is primarily done through config files
+	// Runtime configuration options are limited compared to tmux
+	// Most styling and behavior is set in the Zellij config file (~/.config/zellij/config.kdl)
+	return nil
+}

--- a/proto/map/v1/daemon.pb.go
+++ b/proto/map/v1/daemon.pb.go
@@ -554,8 +554,10 @@ type GetStatusResponse struct {
 	ConnectedAgents int32                  `protobuf:"varint,3,opt,name=connected_agents,json=connectedAgents,proto3" json:"connected_agents,omitempty"`
 	PendingTasks    int32                  `protobuf:"varint,4,opt,name=pending_tasks,json=pendingTasks,proto3" json:"pending_tasks,omitempty"`
 	ActiveTasks     int32                  `protobuf:"varint,5,opt,name=active_tasks,json=activeTasks,proto3" json:"active_tasks,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// Terminal multiplexer being used: "tmux" or "zellij"
+	Multiplexer   string `protobuf:"bytes,6,opt,name=multiplexer,proto3" json:"multiplexer,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetStatusResponse) Reset() {
@@ -621,6 +623,13 @@ func (x *GetStatusResponse) GetActiveTasks() int32 {
 		return x.ActiveTasks
 	}
 	return 0
+}
+
+func (x *GetStatusResponse) GetMultiplexer() string {
+	if x != nil {
+		return x.Multiplexer
+	}
+	return ""
 }
 
 // WatchEventsRequest configures event streaming
@@ -845,7 +854,9 @@ type SpawnedAgentInfo struct {
 	CreatedAt    *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	LogFile      string                 `protobuf:"bytes,6,opt,name=log_file,json=logFile,proto3" json:"log_file,omitempty"`
 	// Agent type: "claude" or "codex"
-	AgentType     string `protobuf:"bytes,7,opt,name=agent_type,json=agentType,proto3" json:"agent_type,omitempty"`
+	AgentType string `protobuf:"bytes,7,opt,name=agent_type,json=agentType,proto3" json:"agent_type,omitempty"`
+	// Terminal multiplexer type: "tmux" or "zellij"
+	Multiplexer   string `protobuf:"bytes,8,opt,name=multiplexer,proto3" json:"multiplexer,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -925,6 +936,13 @@ func (x *SpawnedAgentInfo) GetLogFile() string {
 func (x *SpawnedAgentInfo) GetAgentType() string {
 	if x != nil {
 		return x.AgentType
+	}
+	return ""
+}
+
+func (x *SpawnedAgentInfo) GetMultiplexer() string {
+	if x != nil {
+		return x.Multiplexer
 	}
 	return ""
 }
@@ -1505,14 +1523,15 @@ const file_map_v1_daemon_proto_rawDesc = "" +
 	"\x05force\x18\x01 \x01(\bR\x05force\",\n" +
 	"\x10ShutdownResponse\x12\x18\n" +
 	"\amessage\x18\x01 \x01(\tR\amessage\"\x12\n" +
-	"\x10GetStatusRequest\"\xdb\x01\n" +
+	"\x10GetStatusRequest\"\xfd\x01\n" +
 	"\x11GetStatusResponse\x12\x18\n" +
 	"\arunning\x18\x01 \x01(\bR\arunning\x129\n" +
 	"\n" +
 	"started_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tstartedAt\x12)\n" +
 	"\x10connected_agents\x18\x03 \x01(\x05R\x0fconnectedAgents\x12#\n" +
 	"\rpending_tasks\x18\x04 \x01(\x05R\fpendingTasks\x12!\n" +
-	"\factive_tasks\x18\x05 \x01(\x05R\vactiveTasks\"\x8c\x01\n" +
+	"\factive_tasks\x18\x05 \x01(\x05R\vactiveTasks\x12 \n" +
+	"\vmultiplexer\x18\x06 \x01(\tR\vmultiplexer\"\x8c\x01\n" +
 	"\x12WatchEventsRequest\x122\n" +
 	"\vtype_filter\x18\x01 \x03(\x0e2\x11.map.v1.EventTypeR\n" +
 	"typeFilter\x12!\n" +
@@ -1530,7 +1549,7 @@ const file_map_v1_daemon_proto_rawDesc = "" +
 	"agent_type\x18\x06 \x01(\tR\tagentType\x12)\n" +
 	"\x10skip_permissions\x18\a \x01(\bR\x0fskipPermissions\"F\n" +
 	"\x12SpawnAgentResponse\x120\n" +
-	"\x06agents\x18\x01 \x03(\v2\x18.map.v1.SpawnedAgentInfoR\x06agents\"\xf1\x01\n" +
+	"\x06agents\x18\x01 \x03(\v2\x18.map.v1.SpawnedAgentInfoR\x06agents\"\x93\x02\n" +
 	"\x10SpawnedAgentInfo\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12#\n" +
 	"\rworktree_path\x18\x02 \x01(\tR\fworktreePath\x12\x10\n" +
@@ -1540,7 +1559,8 @@ const file_map_v1_daemon_proto_rawDesc = "" +
 	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x19\n" +
 	"\blog_file\x18\x06 \x01(\tR\alogFile\x12\x1d\n" +
 	"\n" +
-	"agent_type\x18\a \x01(\tR\tagentType\"C\n" +
+	"agent_type\x18\a \x01(\tR\tagentType\x12 \n" +
+	"\vmultiplexer\x18\b \x01(\tR\vmultiplexer\"C\n" +
 	"\x10KillAgentRequest\x12\x19\n" +
 	"\bagent_id\x18\x01 \x01(\tR\aagentId\x12\x14\n" +
 	"\x05force\x18\x02 \x01(\bR\x05force\"G\n" +

--- a/proto/map/v1/daemon.proto
+++ b/proto/map/v1/daemon.proto
@@ -102,6 +102,8 @@ message GetStatusResponse {
   int32 connected_agents = 3;
   int32 pending_tasks = 4;
   int32 active_tasks = 5;
+  // Terminal multiplexer being used: "tmux" or "zellij"
+  string multiplexer = 6;
 }
 
 // WatchEventsRequest configures event streaming
@@ -152,6 +154,8 @@ message SpawnedAgentInfo {
   string log_file = 6;
   // Agent type: "claude" or "codex"
   string agent_type = 7;
+  // Terminal multiplexer type: "tmux" or "zellij"
+  string multiplexer = 8;
 }
 
 // KillAgentRequest requests termination of a spawned agent


### PR DESCRIPTION
## Summary

- Add support for Zellij as an alternative to tmux for managing agent sessions
- Users can configure their preferred multiplexer via config file, environment variable, or default to tmux
- Implements multiplexer abstraction interface for clean separation of concerns

## Changes

- **New files:**
  - `internal/daemon/multiplexer.go` - Interface definition and factory
  - `internal/daemon/multiplexer_tmux.go` - Tmux implementation
  - `internal/daemon/multiplexer_zellij.go` - Zellij implementation

- **Modified files:**
  - `internal/daemon/process.go` - Refactored to use Multiplexer interface
  - `internal/daemon/server.go` - Initialize multiplexer from config
  - `internal/cli/config.go` - Added `multiplexer` default
  - `internal/cli/root.go` - Added `getMultiplexer()` helper
  - `internal/cli/up.go` - Pass multiplexer to daemon config
  - `internal/cli/agent_watch.go` - Support both multiplexers with appropriate keyboard hints
  - `internal/cli/clean.go` - Clean sessions from both multiplexers
  - `proto/map/v1/daemon.proto` - Added multiplexer field to status messages
  - `README.md` - Documentation for multiplexer configuration

## Configuration

The multiplexer can be configured via (in priority order):
1. Environment variable: `MAP_MULTIPLEXER=zellij`
2. Config file: `~/.mapd/config.yaml` with `multiplexer: zellij`
3. Default: `tmux`

## Test plan

- [ ] Verify tmux still works as default
- [ ] Test with `MAP_MULTIPLEXER=zellij map up`
- [ ] Test `map config set multiplexer zellij`
- [ ] Test `map agent watch` shows correct keyboard shortcuts for each multiplexer
- [ ] Test `map clean` removes sessions from both multiplexers
- [ ] Run `make test` and `golangci-lint run`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)